### PR TITLE
Handle idea.license

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ of IDEA, either by finding and downloading the latest version directly
 from Jetbrain's servers or by being pointed to a build output directory
 and use that.
 
+If you provide an *idea.license* file, this license is applied to the
+genereated package. This allows to generate a certified package for
+the Ultimate edition of the IDE.
+
 OPTIONS
 --------
 

--- a/build-package
+++ b/build-package
@@ -95,6 +95,16 @@ Original idea.vmoptions:
   cp root/usr/share/jetbrains/intellij-idea/bin/idea.vmoptions $fn
   cat $fn | grep -v yjpagent > root/usr/share/jetbrains/intellij-idea/bin/idea.vmoptions
   rm $fn
+
+  # If idea.license is provided in the bin directory of intellij-idea, this
+  # license is applied to the genereated package. This allows to generate a
+  # certified package for the Ultimate edition of the IDE.
+  if [ -f "idea.license" ]
+  then
+    bin_dir="root/usr/share/jetbrains/intellij-idea/bin"
+    echo "Copy licence file to $bin_dir"
+    cp idea.license bin_dir
+  fi
 }
 
 calculate_package_filename() {

--- a/build-package
+++ b/build-package
@@ -103,7 +103,7 @@ Original idea.vmoptions:
   then
     bin_dir="root/usr/share/jetbrains/intellij-idea/bin"
     echo "Copy licence file to $bin_dir"
-    cp idea.license bin_dir
+    cp idea.license $bin_dir
   fi
 }
 


### PR DESCRIPTION
If idea.license is provided in the bin directory of intellij-idea, this
license is applied to the genereated package. This allows to generate a
certified package for the Ultimate edition of the IDE.