### PR TITLE
Added openjdk-8 to controlfile because its available in Debian 8…

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -3,8 +3,8 @@ Section: devel
 Version: VERSION
 Maintainer: Trygve Laugstøl <trygvis@inamo.no>
 Architecture: all
-Depends: openjdk-7-jdk | sun-java6-jdk | openjdk-6-jdk | ibm-j2sdk1.7
-Suggests: openjdk-6-source, openjdk-7-source
+Depends: openjdk-8-jdk |openjdk-7-jdk | sun-java6-jdk | openjdk-6-jdk | ibm-j2sdk1.7
+Suggests: openjdk-6-source, openjdk-7-source, openjdk-8-source
 Conflicts: intellij-idea-OTHER_FLAVOR_LOWER, intellij-idea-OTHER_FLAVOR, intellij-idea-FLAVOR
 Description: The Most Intelligent Java IDE
 

--- a/idea.in
+++ b/idea.in
@@ -3,6 +3,8 @@
 paths="
 /usr/lib/jvm/java-8-oracle
 
+/usr/lib/jvm/java-8-openjdk
+/usr/lib/jvm/java-8-openjdk-amd64
 /usr/lib/jvm/java-7-openjdk
 /usr/lib/jvm/java-7-openjdk-amd64
 /usr/jdk/instances/jdk1.7.0


### PR DESCRIPTION
… backports and Debian 9 testing.