### PR TITLE
Deleting unnessary native binaries.

### DIFF
--- a/build-package
+++ b/build-package
@@ -112,6 +112,22 @@ Original idea.vmoptions:
     echo "Copy licence file to $bin_dir"
     cp idea.license $bin_dir
   fi
+
+  # remove unnecessary binaries
+  echo "Remove unneccesary binaries (for other OSes and architectures)"
+  plugin_path="root/usr/share/intellij-idea/plugins"
+  rm -r $plugin_path/tfsIntegration/lib/native/{aix,freebsd,hpux,macosx,win32}
+  rm -r $plugin_path/gradle/lib/native-platform-{freebsd,osx,windows}*
+  case "$platform" in
+   solaris)
+    rm -r $plugin_path/tfsIntegration/lib/native/linux
+    rm -r $plugin_path/gradle/lib/native-platform-linux*
+     ;;
+   debian)
+    rm -r $plugin_path/tfsIntegration/lib/native/solaris
+    rm -r $plugin_path/tfsIntegration/lib/native/linux/{arm,ppc}
+    ;;
+  esac
 }
 
 calculate_package_filename() {


### PR DESCRIPTION
Debian part was tested but have no solaris box lying around here. 
For my self I stripped everything to x86_64 only, so I kept the PR generic and kept the 32bit libraries. If you think it makes sense to build in a cmd flag for $ARCH I would create a PR. 