### PR TITLE
added -c option to wget

### DIFF
--- a/build-package
+++ b/build-package
@@ -325,7 +325,7 @@ then
   #fi
 
   echo "Downloading version $version..."
-  if [ `wget -q -P download -N $url; echo $?` != "0" ]
+  if [ `wget -c -q -P download -N $url; echo $?` != "0" ]
   then
     echo "Could not download $url" >&2
     exit 1


### PR DESCRIPTION
continue download the package that is unfinished,
may be useful for unexpected network corruption.
