### PR TITLE
Update to 2016.3

### DIFF
--- a/build-package
+++ b/build-package
@@ -44,7 +44,7 @@ find_latest() {
 #    IDEA_URL="http://confluence.jetbrains.net/display/IDEADEV/IDEA+14.1+EAP"
 #    IDEA_URL="http://confluence.jetbrains.net/display/IDEADEV/IDEA+15+EAP"
 #    IDEA_URL="http://confluence.jetbrains.net/display/IDEADEV/IDEA+16+EAP"
-    IDEA_URL="https://confluence.jetbrains.com/display/IDEADEV/IDEA+2016.1+EAP"
+    IDEA_URL="https://confluence.jetbrains.com/display/IDEADEV/IDEA+2016.3+EAP"
   fi
 
   export LC_ALL=C


### PR DESCRIPTION
Thanks for the continued updates to fit the wiki format.

This simply bumps the EAP URL to 2016.3.
Works for me with:
./build-package # This gave me intellij-idea-iu-2016.3.3.deb
./build-package -f IC -v 2016.3.3 # This gave me intellij-idea-ic-2016.3.3.deb